### PR TITLE
Create a bank for the waveform of ALERT, AHDC::wf136

### DIFF
--- a/hitprocess/clas12/alert/ahdc_hitprocess.cc
+++ b/hitprocess/clas12/alert/ahdc_hitprocess.cc
@@ -94,7 +94,8 @@ map<string, double> ahdc_HitProcess::integrateDgt(MHit* aHit, int hitn) {
 	dgtz["ADC_time"]  = output["t_ovr"]; // ns
 	dgtz["ADC_ped"]   = (int) output["noise_level"]; // adc
 	dgtz["ADC_integral"] = (int) output["integral"]; // adc per 44 ns
-	dgtz["ADC_timestamp"] = output["t_start"]; // ns
+	dgtz["ADC_timestamp"] = 0;
+	dgtz["ADC_t_start"] = output["t_start"]; // ns
 	dgtz["ADC_t_cfd"] = output["t_cfd"]; // ns
 	dgtz["ADC_mctime"] = Signal->GetMCTime(); // ns
 	dgtz["ADC_nsteps"] = Signal->Get_nsteps();
@@ -102,6 +103,8 @@ map<string, double> ahdc_HitProcess::integrateDgt(MHit* aHit, int hitn) {
 
 	//dgtz["TDC_order"] = 0;
 	//dgtz["TDC_TDC"]   = output["t_start"];
+	dgtz["wf136_order"] = 1;
+	dgtz["wf136_timestamp"] = 0;
 	std::vector<double> SDgtz = Signal->GetDgtz();
 	for (int itr=1;itr<=136;itr++){
 		std::ostringstream sEntry;

--- a/hitprocess/clas12/alert/ahdc_hitprocess.cc
+++ b/hitprocess/clas12/alert/ahdc_hitprocess.cc
@@ -100,9 +100,14 @@ map<string, double> ahdc_HitProcess::integrateDgt(MHit* aHit, int hitn) {
 	dgtz["ADC_nsteps"] = Signal->Get_nsteps();
 	dgtz["ADC_mcEtot"] = Signal->GetMCEtot(); // keV
 
-	dgtz["TDC_order"] = 0;
-	dgtz["TDC_TDC"]   = output["t_start"];
-	
+	//dgtz["TDC_order"] = 0;
+	//dgtz["TDC_TDC"]   = output["t_start"];
+	std::vector<double> SDgtz = Signal->GetDgtz();
+	for (int itr=1;itr<=136;itr++){
+		std::ostringstream sEntry;
+		sEntry << "wf136_s" << itr;
+		dgtz[sEntry.str()] = (int) SDgtz.at(itr-1);
+	}
 	delete Signal;
 	
 	// define conditions to reject hit

--- a/output/hipoSchemas.cc
+++ b/output/hipoSchemas.cc
@@ -34,7 +34,7 @@ HipoSchema :: HipoSchema()
 	// detectors
 	//alertAhdcADCchema = hipo::schema("ALRTDC::adc",  22400, 11);
 	//alertAtofADCchema = hipo::schema("ALRTTOF::adc", 22500, 11);
-	alertAhdcWF136chema = hipo::schema("AHDC::wf136",22400, 13);
+	alertAhdcWF136chema = hipo::schema("AHDC::wf:136",22400, 13);
 	alertAhdcTDCchema = hipo::schema("AHDC::tdc",	 22400, 12);
 	alertAhdcADCchema = hipo::schema("AHDC::adc",	 22400, 11);
 	alertAtofADCchema = hipo::schema("ATOF::adc",	 22500, 11);
@@ -171,7 +171,7 @@ HipoSchema :: HipoSchema()
 	// The names corresponds to the hit process routine names, capitalized
 	//schemasToLoad["ALRTDC::adc"]  = alertAhdcADCchema;
 	//schemasToLoad["ALRTTOF::adc"] = alertAtofADCchema;
-	schemasToLoad["AHDC::wf136"] = alertAhdcWF136chema;
+	schemasToLoad["AHDC::wf:136"] = alertAhdcWF136chema;
 	schemasToLoad["AHDC::adc"]  = alertAhdcADCchema;
 	schemasToLoad["AHDC::tdc"]  = alertAhdcTDCchema;
 	schemasToLoad["ATOF::adc"] = alertAtofADCchema;

--- a/output/hipoSchemas.cc
+++ b/output/hipoSchemas.cc
@@ -98,9 +98,9 @@ HipoSchema :: HipoSchema()
 
 	
 	// detectors
-	alertAhdcADCchema.parse("sector/B, layer/B, component/S, order/B, ADC/I, time/F, ped/S, integral/I, timestamp/F, t_cfd/F, mctime/F, nsteps/I, mcEtot/F");
+	alertAhdcADCchema.parse("sector/B, layer/B, component/S, order/B, ADC/I, time/F, ped/S, integral/I, timestamp/S, t_start/F, t_cfd/F, mctime/F, nsteps/I, mcEtot/F");
 	std::ostringstream ListOfAhdcWF136;
-	ListOfAhdcWF136 << "sector/B, layer/B, component/S";
+	ListOfAhdcWF136 << "sector/B, layer/B, component/S, order/B, timestamp/S";
 	for (int itr=1;itr<=136;itr++){
 		ListOfAhdcWF136 << ", s" << itr << "/I";
 	}

--- a/output/hipoSchemas.cc
+++ b/output/hipoSchemas.cc
@@ -34,6 +34,7 @@ HipoSchema :: HipoSchema()
 	// detectors
 	//alertAhdcADCchema = hipo::schema("ALRTDC::adc",  22400, 11);
 	//alertAtofADCchema = hipo::schema("ALRTTOF::adc", 22500, 11);
+	alertAhdcWF136chema = hipo::schema("AHDC::wf136",22400, 13);
 	alertAhdcTDCchema = hipo::schema("AHDC::tdc",	 22400, 12);
 	alertAhdcADCchema = hipo::schema("AHDC::adc",	 22400, 11);
 	alertAtofADCchema = hipo::schema("ATOF::adc",	 22500, 11);
@@ -97,8 +98,13 @@ HipoSchema :: HipoSchema()
 
 	
 	// detectors
-	//alertAhdcADCchema.parse("sector/B, layer/B, component/S, order/B, ADC/I, time/F, ped/S, integral/I, timestamp/L");
 	alertAhdcADCchema.parse("sector/B, layer/B, component/S, order/B, ADC/I, time/F, ped/S, integral/I, timestamp/F, t_cfd/F, mctime/F, nsteps/I, mcEtot/F");
+	std::ostringstream ListOfAhdcWF136;
+	ListOfAhdcWF136 << "sector/B, layer/B, component/S";
+	for (int itr=1;itr<=136;itr++){
+		ListOfAhdcWF136 << ", s" << itr << "/I";
+	}
+	alertAhdcWF136chema.parse(ListOfAhdcWF136.str());
 	alertAhdcTDCchema.parse("sector/B, layer/B, component/S, order/B, TDC/I, ped/S");
 	alertAtofADCchema.parse("sector/B, layer/B, component/S, order/B, ADC/I, time/F, ped/S");
 
@@ -165,6 +171,7 @@ HipoSchema :: HipoSchema()
 	// The names corresponds to the hit process routine names, capitalized
 	//schemasToLoad["ALRTDC::adc"]  = alertAhdcADCchema;
 	//schemasToLoad["ALRTTOF::adc"] = alertAtofADCchema;
+	schemasToLoad["AHDC::wf136"] = alertAhdcWF136chema;
 	schemasToLoad["AHDC::adc"]  = alertAhdcADCchema;
 	schemasToLoad["AHDC::tdc"]  = alertAhdcTDCchema;
 	schemasToLoad["ATOF::adc"] = alertAtofADCchema;

--- a/output/hipoSchemas.cc
+++ b/output/hipoSchemas.cc
@@ -98,11 +98,11 @@ HipoSchema :: HipoSchema()
 
 	
 	// detectors
-	alertAhdcADCchema.parse("sector/B, layer/B, component/S, order/B, ADC/I, time/F, ped/S, integral/I, timestamp/S, t_start/F, t_cfd/F, mctime/F, nsteps/I, mcEtot/F");
+	alertAhdcADCchema.parse("sector/B, layer/B, component/S, order/B, ADC/I, time/F, ped/S, integral/I, timestamp/L, t_start/F, t_cfd/F, mctime/F, nsteps/I, mcEtot/F");
 	std::ostringstream ListOfAhdcWF136;
-	ListOfAhdcWF136 << "sector/B, layer/B, component/S, order/B, timestamp/S";
+	ListOfAhdcWF136 << "sector/B, layer/B, component/S, order/B, timestamp/L";
 	for (int itr=1;itr<=136;itr++){
-		ListOfAhdcWF136 << ", s" << itr << "/I";
+		ListOfAhdcWF136 << ", s" << itr << "/S";
 	}
 	alertAhdcWF136chema.parse(ListOfAhdcWF136.str());
 	alertAhdcTDCchema.parse("sector/B, layer/B, component/S, order/B, TDC/I, ped/S");

--- a/output/hipoSchemas.h
+++ b/output/hipoSchemas.h
@@ -20,6 +20,7 @@ public:
 	hipo::schema fluxADCSchema;
 
 	// detectors
+	hipo::schema alertAhdcWF136chema;
 	hipo::schema alertAhdcADCchema;
 	hipo::schema alertAhdcTDCchema;
 	hipo::schema alertAtofADCchema;

--- a/output/hipo_output.cc
+++ b/output/hipo_output.cc
@@ -645,8 +645,8 @@ void hipo_output :: writeG4DgtIntegrated(outputContainer* output, vector<hitOutp
 	hipo::schema detectorTDCSchema = output->hipoSchema->getSchema(hitType, 1);
 	hipo::bank detectorADCBank(detectorADCSchema, HO.size());
 	hipo::bank detectorTDCBank(detectorTDCSchema, HO.size());
-	// Specific to AHDC and AHDC::wf136
-	hipo::schema ahdcWF136Schema = (output->hipoSchema)->schemasToLoad["AHDC::wf136"];
+	// Specific to AHDC and AHDC::wf:136
+	hipo::schema ahdcWF136Schema = (output->hipoSchema)->schemasToLoad["AHDC::wf:136"];
 	hipo::bank ahdcWF136Bank(ahdcWF136Schema, HO.size());
 
 	// check if there is at least one adc or tdc var


### PR DESCRIPTION
Here is the modifications that I have made to manage to create a new bank, `AHDC::wf:136`, to save the waveform of the AHDC signal. This code has to be run with the corresponding pull request for `gemc/detectors`.

The following figures show the result.

![Screenshot from 2024-10-23 18-40-56](https://github.com/user-attachments/assets/a8657005-e8af-4464-a374-68e3465038a2)

