### PR TITLE
Enhance the readability of the AHDC digitization

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2,7 +2,7 @@ from init_env import init_environment
 
 # adding ccdb as temporary dependency
 # will be removed once the hit process routines are plugins
-env = init_environment("qt5 geant4 clhep xercesc ccdb mlibrary cadmesh hipo c12bfields")
+env = init_environment("qt5 geant4 clhep xercesc ccdb mlibrary cadmesh hipo c12bfields root")
 env.Append(CXXFLAGS=['-std=c++17'])
 
 # addressing shortcoming of geant4-config 10.7.4 not returning all libraries

--- a/SConstruct
+++ b/SConstruct
@@ -2,7 +2,7 @@ from init_env import init_environment
 
 # adding ccdb as temporary dependency
 # will be removed once the hit process routines are plugins
-env = init_environment("qt5 geant4 clhep xercesc ccdb mlibrary cadmesh hipo c12bfields root")
+env = init_environment("qt5 geant4 clhep xercesc ccdb mlibrary cadmesh hipo c12bfields")
 env.Append(CXXFLAGS=['-std=c++17'])
 
 # addressing shortcoming of geant4-config 10.7.4 not returning all libraries

--- a/hitprocess/clas12/alert/ahdc_hitprocess.cc
+++ b/hitprocess/clas12/alert/ahdc_hitprocess.cc
@@ -97,11 +97,21 @@ map<string, double> ahdc_HitProcess::integrateDgt(MHit* aHit, int hitn) {
 	dgtz["ADC_nsteps"] = Signal->nsteps;
 	dgtz["ADC_mcEtot"] = Signal->GetMCEtot(); // keV
 
+	std::map<std::string,double> output2 = Signal->Extract();
+	if (Signal->nsteps > 10){
+		std::cout << "======> Test ahdcExtractor" << std::endl;
+		std::cout << "    noise_level=" << output["noise_level"] << ", adcOffset=" << output2["adcOffset"] << std::endl;
+		std::cout << "    max_value=" << output["max_value"] - output["noise_level"] << ", adcMax=" << output2["adcMax"] << std::endl;
+		std::cout << "    t_start=" << output["t_start"] << ", timeRiseCFA=" << output2["timeRiseCFA"] << std::endl;
+		std::cout << "    t_ovr_end=" << output["t_start"] + output["t_ovr"] << ", timeFallCFA=" << output2["timeFallCFA"] << std::endl;
+		std::cout << "    t_cfd=" << output["t_cfd"] << ", timeCFD=" << output2["timeCFD"] << std::endl;
+		std::cout << "    t_ovr=" << output["t_ovr"] << ", timeOverThresholdCFA=" << output2["timeOverThresholdCFA"] << std::endl;
+	}
 	//dgtz["TDC_order"] = 0;
 	//dgtz["TDC_TDC"]   = output["t_start"];
 	dgtz["wf136_order"] = 1;
 	dgtz["wf136_timestamp"] = 0;
-	std::vector<double> SDgtz = Signal->GetDgtz();
+	std::vector<short> SDgtz = Signal->GetDgtz();
 	for (int itr=1;itr<=136;itr++){
 		std::ostringstream sEntry;
 		sEntry << "wf136_s" << itr;
@@ -283,7 +293,7 @@ void ahdcSignal::Digitize(){
 	for (int i=0;i<Npts;i++) {
 		double value = this->operator()(tmin + i*samplingTime); //in keV/ns
 		value = (int) floor(electronYield*value + Noise.at(i)); //convert in ADC +  noise
-		int adc = (value < ADC_LIMIT) ? value : ADC_LIMIT; // saturation effect 
+		short adc = (value < ADC_LIMIT) ? value : ADC_LIMIT; // saturation effect 
 		Dgtz.push_back(adc);
 	}
 }
@@ -326,7 +336,7 @@ std::map<std::string,double> ahdcSignal::Decode(){
 	// define noise and threshold
 	double noise = 0;
 	for (int i=0;i<5;i++){ noise += Noise.at(i);} 
-	noise = noise/5; 
+	noise = noise/5;
 	double threshold = (max_value+noise)/2.0;
 	
 	// compute t_start
@@ -351,6 +361,7 @@ std::map<std::string,double> ahdcSignal::Decode(){
 		}
 		else { break;}
 	}      // at this stage : i_ovr-1 < t_ovr/samplingTime < i_ovr
+	
 	if (i_ovr < Npts-2) {
 		i1 = i_ovr-1; 
 		i2 = i_ovr;
@@ -389,13 +400,13 @@ std::map<std::string,double> ahdcSignal::Decode(){
 
 double ahdcSignal::Apply_CFD(double CFD_fraction, int CFD_delay){
 	int Npts = Dgtz.size();
-	std::vector<double> Data = Dgtz;
+	std::vector<short> Data =  Dgtz;
 	// Remove noise 
-	double noise = 0;
+	short noise = 0;
 	for (int i=0;i<5;i++){
 		noise += Data.at(i);
 	}
-	noise = noise/5;
+	noise = (short) noise/5;
 	double ymax = 0;
 	for (int i=0;i<Npts;i++){
 		Data[i] = Data.at(i) - noise;
@@ -456,4 +467,297 @@ double ahdcSignal::GetMCEtot(){
 	return mcEtot;
 }
 
+#include <TString.h>
+std::map<std::string,double> ahdcSignal::Extract(){
+	ahdcExtractor T(samplingTime,0.5f,5,0.3f);
+	T.adcOffset = (short) (Dgtz[0] + Dgtz[1] + Dgtz[2] + Dgtz[3] + Dgtz[4])/5;
+	std::map<std::string,double> output = T.extract(Dgtz);
+	if (nsteps > 10){
+		T.Show(TString::Format("./output/SignalDecoded_%d_%d_%d_%d.pdf",hitn,sector,layer,component).Data());
+		T.ShowCFD(TString::Format("./output/SignalCFD_%d_%d_%d_%d.pdf",hitn,sector,layer,component).Data());
+	}
+	return output;
+}
 
+std::map<std::string,double> ahdcExtractor::extract(const std::vector<short> samples){
+	samplesCorr = samples;
+	this->waveformCorrection();
+	this->fitAverage();
+	this->fitParabolic();
+	this->computeTimeAtConstantFractionAmplitude();
+	this->computeTimeUsingConstantFractionDiscriminator();
+	//this->fineTimeStampCorrection();
+	std::map<std::string,double> output;
+	output["binMax"] = binMax;
+	output["binOffset"] = binOffset;
+	output["adcMax"] = adcMax;
+	output["timeMax"] = timeMax;
+	output["integral"] = integral;
+	output["timeRiseCFA"] = timeRiseCFA;
+	output["timeFallCFA"] = timeFallCFA;
+	output["timeOverThresholdCFA"] = timeOverThresholdCFA;
+	output["timeCFD"] = timeCFD;
+	output["adcOffset"] = adcOffset;
+	return output;
+
+}
+
+void ahdcExtractor::waveformCorrection(){
+	binNumber = samplesCorr.size();
+	binMax = 0;
+	adcMax = (short) (samplesCorr[0] - adcOffset);
+	integral = 0;
+	for (int bin = 0; bin < binNumber; bin++){
+		samplesCorr[bin] = (short) (samplesCorr[bin] - adcOffset);
+		if (adcMax < samplesCorr[bin]){
+			adcMax = samplesCorr[bin];
+			binMax = bin;
+		}
+		integral += samplesCorr[bin];
+	}
+	/*
+	 * If adcMax + adcOffset == ADC_LIMIT, that means there is saturation
+	 * In that case, binMax is the middle of the first plateau
+	 * This convention can be changed
+	 */
+	if ((short) adcMax + adcOffset == ADC_LIMIT) {
+		int binMax2 = binMax;
+		for (int bin = binMax; bin < binNumber; bin++){
+			if (samplesCorr[bin] + adcOffset == ADC_LIMIT) {
+				binMax2 = bin;
+			}
+			else {
+				break;
+			}
+		}
+		binMax = (binMax + binMax2)/2;
+	}
+	binOffset = sparseSample*binMax;
+	timeMax = (binMax + binOffset)*samplingTime;
+}
+
+
+void ahdcExtractor::fitAverage(){
+	if ((binMax - 2 >= 0) && (binMax + 2 <= binNumber - 1)){
+		adcMax = 0;
+		for (int bin = binMax - 2; bin <= binMax + 2; bin++){
+			adcMax += samplesCorr[bin];
+		}
+		adcMax = adcMax/5;
+	}
+}
+
+void ahdcExtractor::fitParabolic(){}
+
+void ahdcExtractor::fineTimeStampCorrection(){}
+
+void ahdcExtractor::computeTimeAtConstantFractionAmplitude(){
+	float threshold = amplitudeFractionCFA*adcMax;
+	// timeRiseCFA
+	int binRise = 0;
+	for (int bin = 0; bin < binMax; bin++){
+		if (samplesCorr[bin] < threshold)
+			binRise = bin;  // last pass below threshold and before adcMax
+	} // at this stage : binRise < timeRiseCFA/samplingTime <= binRise + 1 // timeRiseCFA is determined by assuming a linear fit between binRise and binRise + 1
+	float slopeRise = 0;
+	if (binRise + 1 <= binNumber-1)
+		slopeRise = samplesCorr[binRise+1] - samplesCorr[binRise];
+	float fittedBinRise = (slopeRise == 0) ? binRise : binRise + (threshold - samplesCorr[binRise])/slopeRise;
+	timeRiseCFA = (fittedBinRise + binOffset)*samplingTime; // binOffset is determined in wavefromCorrection() // must be the same for all time ? // or must be defined using fittedBinRise*sparseSample
+
+	// timeFallCFA
+	int binFall = binMax;
+	for (int bin = binMax; bin < binNumber; bin++){
+		if (samplesCorr[bin] > threshold){
+				binFall = bin;
+		}
+		else {
+				binFall = bin;
+				break; // first pass below the threshold
+		}
+	} // at this stage : binFall - 1 <= timeRiseCFA/samplingTime < binFall // timeFallCFA is determined by assuming a linear fit between binFall - 1 and binFall
+	float slopeFall = 0;
+	if (binFall - 1 >= 0)
+		slopeFall = samplesCorr[binFall] - samplesCorr[binFall-1];
+	float fittedBinFall = (slopeFall == 0) ? binFall : binFall-1 + (threshold - samplesCorr[binFall-1])/slopeFall;
+	timeFallCFA = (fittedBinFall + binOffset)*samplingTime;
+	
+	// timeOverThreshold
+	timeOverThresholdCFA = timeFallCFA - timeRiseCFA;
+}
+
+void ahdcExtractor::computeTimeUsingConstantFractionDiscriminator(){
+	std::vector<float> signal(binNumber,0.0);
+	// signal generation
+	for (int bin = 0; bin < binNumber; bin++){
+		signal[bin] = (1 - fractionCFD)*samplesCorr[bin]; // we fill it with a fraction of the original signal
+		if (bin < binNumber - binDelayCFD)
+			signal[bin] += -1*fractionCFD*samplesCorr[bin + binDelayCFD]; // we advance and invert a complementary fraction of the original signal and superimpose it to the previous signal
+	}
+	// determine the two humps
+	int binHumpSup = 0;
+	int binHumpInf = 0;
+	for (int bin = 0; bin < binNumber; bin++){
+		if (signal[bin] > signal[binHumpSup])
+			binHumpSup = bin;
+	}
+	for (int bin = 0; bin < binHumpSup; bin++){ // this loop has been added to be sure : binHumpInf < binHumpSup
+		if (signal[bin] < signal[binHumpInf])
+			binHumpInf = bin;
+	}
+	// research for zero
+	int binZero = 0;
+	for (int bin = binHumpInf; bin <= binHumpSup; bin++){
+		if (signal[bin] < 0)
+			binZero = bin; // last pass below zero
+	} // at this stage : binZero < timeCFD/samplingTime <= binZero + 1 // timeCFD is determined by assuming a linear fit between binZero and binZero + 1
+	float slopeCFD = 0;
+	if (binZero + 1 <= binNumber)
+		slopeCFD = signal[binZero+1] - signal[binZero];
+	float fittedBinZero = (slopeCFD == 0) ? binZero : binZero + (0 - signal[binZero])/slopeCFD;
+	timeCFD = (fittedBinZero + binOffset)*samplingTime;
+	//
+	samplesCFD = signal;
+}
+
+#include "TCanvas.h"
+#include "TGraph.h"
+#include "TAxis.h"
+#include "TStyle.h"
+#include "TString.h"
+#include "TH1.h"
+#include "TGraphPolar.h"
+#include "TGaxis.h"
+#include <time.h>
+#include "TLine.h"
+#include "TGaxis.h"
+#include "TLatex.h"
+#include "TLegend.h"
+#include "TArrow.h"
+#include <fstream>
+
+void ahdcExtractor::Show(const char * filename){
+	double tmin = 0;
+	double tmax = 6000;
+        double threshold = adcOffset + amplitudeFractionCFA*adcMax;
+
+        // Main graph
+        double ymax = 0;
+        TGraph* gr1 = new TGraph(binNumber);
+        for (int i=0;i<binNumber;i++){
+                int adc = samplesCorr.at(i) + adcOffset;
+                if (ymax < adc) ymax = adc;
+                gr1->SetPoint(i,tmin + i*samplingTime,adc);
+        }
+        // Graph for filling
+	int binNumberOVR = 0; // binNumberOverthresholdCFA
+	for (int bin=0; bin< binNumber;bin++){
+		if ((bin*samplingTime > timeRiseCFA) && (bin*samplingTime < timeFallCFA))
+			binNumberOVR++;
+	}
+        TGraph* gr2 = new TGraph(binNumberOVR+2);
+        gr2->SetPoint(0,timeRiseCFA,threshold);
+        gr2->SetPoint(binNumberOVR+1,timeFallCFA, threshold);
+	int binRiseCFA = (int) timeRiseCFA/samplingTime;
+        for (int i=1;i<=binNumberOVR;i++){
+                gr2->SetPoint(i,tmin+samplingTime*(binRiseCFA+i),samplesCorr.at(binRiseCFA+i)+adcOffset);
+        }
+
+        // Plot graph
+        TCanvas* canvas1 = new TCanvas("c1","c1 title",1366,768);
+        gr1->SetTitle("");
+        //gr1->SetTitle(TString::Format("%s : p = #Box MeV, #theta = #Box deg, #phi = #Box deg",pid2name[pid].data()));
+        gr1->GetXaxis()->SetTitle("Time (ns)");
+        gr1->GetXaxis()->SetTitleSize(0.05);
+        gr1->GetYaxis()->SetTitle("Charge (adc)");
+        gr1->GetYaxis()->SetTitleSize(0.05);
+        gr1->GetYaxis()->SetRangeUser(0,ymax+0.05*ymax);
+        gr1->SetMarkerColor(kBlack);
+        gr1->SetMarkerSize(5);
+        gr1->SetLineColor(kBlue);
+        gr1->Draw("APL");
+        gr2->SetFillColorAlpha(kGreen, 1.0);
+        gr2->Draw("F");
+
+        // View decoding
+        TLine* line1 = new TLine(timeRiseCFA,0,timeRiseCFA,threshold); line1->SetLineWidth(1); line1->SetLineColor(kRed); line1->SetLineStyle(2); line1->Draw(); // timeRiseCFA
+        TLine* line2 = new TLine(0,threshold,timeRiseCFA,threshold); line2->SetLineWidth(1); line2->SetLineColor(kRed); line2->SetLineStyle(2); line2->Draw(); // timeRiseCFA
+        TLine* line3 = new TLine(timeFallCFA,0,timeFallCFA,threshold); line3->SetLineWidth(1); line3->SetLineColor(kRed); line3->SetLineStyle(2); line3->Draw(); // timeFallCFA
+        TArrow* arrow1 = new TArrow(timeRiseCFA,threshold,timeFallCFA,threshold,0.02,"<>"); arrow1->SetLineWidth(1); arrow1->SetLineColor(kRed); arrow1->Draw(); // timeOverThresholdCFA
+        TLine* line4 = new TLine(tmin,adcOffset,tmax,adcOffset); line4->SetLineWidth(1); line4->SetLineColor(kRed); line4->SetLineStyle(2); line4->Draw(); // adcOffset
+        TLine* line5 = new TLine(0,adcMax+adcOffset,timeMax,adcMax+adcOffset); line5->SetLineWidth(1); line5->SetLineColor(kRed); line5->SetLineStyle(2); line5->Draw(); // adcMax+adcOffset
+        TLine* line6 = new TLine(timeMax,0,timeMax,adcMax+adcOffset); line6->SetLineWidth(1); line6->SetLineColor(kRed); line6->SetLineStyle(2); line6->Draw(); // adcMax+adcOffset
+
+        TLatex data;
+        data.SetTextSize(0.03);
+        data.SetTextAlign(13);
+        data.DrawLatexNDC(0.5,0.8,TString::Format("#bf{#bf{timeRiseCFA} =  %.2lf ns}",timeRiseCFA).Data());
+        data.DrawLatexNDC(0.5,0.8-0.05,TString::Format("#bf{#bf{timeOverThresholdCFA} =  %.2lf ns}",timeOverThresholdCFA).Data());
+        data.DrawLatexNDC(0.5,0.8-0.05*2,TString::Format("#bf{#bf{adcMax+adcOffset} =  %.0lf adc }",adcMax+adcOffset).Data());
+        data.DrawLatexNDC(0.5,0.8-0.05*3,TString::Format("#bf{#bf{integral} =  %.0lf adc per 44 ns}",integral).Data());
+        data.DrawLatexNDC(0.5,0.8-0.05*4,TString::Format("#bf{#bf{adcOffset} =  %d adc}",adcOffset).Data());
+        data.DrawLatexNDC(0.5,0.8-0.05*5,"#bf{1 adc =  10^{-5} keV/ns }");
+        data.DrawLatexNDC(0.5,0.8-0.05*6,TString::Format("#bf{#bf{timeCFD} = %.2lf ns}",timeCFD));
+        data.SetTextAlign(11);
+        data.DrawLatex(timeRiseCFA,0+(adcMax+adcOffset)*0.02,"timeRiseCFA");
+        data.DrawLatex(timeMax,(adcMax+adcOffset)+(adcMax+adcOffset)*0.02,"adcMax+adcOffset");
+        data.DrawLatex(timeMax,threshold,"timeOverThresholdCFA");
+        data.DrawLatex(0+tmax*0.02,threshold,"threshold");
+        data.DrawLatex(tmax, adcOffset+(adcMax+adcOffset)*0.02,"adcOffset");
+
+        canvas1->Print(filename);
+        delete line1; delete line2; delete line3; delete line5;
+        delete gr1; delete gr2; delete arrow1;
+        delete canvas1;
+}
+
+void ahdcExtractor::ShowCFD(const char * filename){
+	double tmin = 0;
+	double tmax = 6000;
+	TCanvas* canvas1 = new TCanvas("c1","c1 title",1366,768);
+	TGraph* gr1 = new TGraph(binNumber);
+	TGraph* gr2 = new TGraph(binNumber);
+	for (int i=0;i<binNumber;i++){
+		gr1->SetPoint(i,tmin + i*samplingTime,samplesCorr.at(i)+adcOffset);
+		gr2->SetPoint(i,tmin + i*samplingTime,samplesCFD.at(i));
+	}
+	gr2->SetTitle(TString::Format("#bf{CFD},  fraction = %.1lf, delay = %d index units",fractionCFD,binDelayCFD));
+        gr2->GetXaxis()->SetTitle("Time (ns)");
+        gr2->GetXaxis()->SetTitleSize(0.05);
+        gr2->GetYaxis()->SetTitle("Charge (adc)");
+        gr2->GetYaxis()->SetTitleSize(0.05);
+        //gr2->SetLineStyle(1);
+        gr2->SetLineColor(kRed);
+        gr2->SetMarkerColor(kRed);
+        gr2->SetMarkerSize(5);
+        gr2->GetYaxis()->SetRangeUser(-fractionCFD*adcMax-0.1*adcMax,adcOffset+adcMax+0.1*adcMax);
+        gr2->Draw("ALP");
+
+        gr1->SetMarkerColor(kBlue);
+        gr1->SetMarkerSize(5);
+        gr1->SetLineColor(kBlue);
+        //gr1->SetLineStyle(2);
+        gr1->Draw("PL");
+
+        TGaxis* axis1 = new TGaxis(tmin,0,tmax,0,tmin,tmax,510,"");
+        axis1->SetLineColor(kGreen);
+        axis1->SetLabelColor(kGreen);
+        //axis1->SetTitle("index units");
+        axis1->Draw();
+
+        TLegend* legend = new TLegend(0.7,0.8,0.9,0.9);
+        legend->AddEntry(gr1,"Digitized signal","l");
+        legend->AddEntry(gr2,"CFD signal","l");
+        legend->Draw();
+
+        TLatex data;
+        data.SetTextSize(0.04);
+        data.SetTextAlign(13);
+        data.DrawLatexNDC(0.7,0.6,TString::Format("#bf{#bf{timeCFD} =  %.2lf ns}",timeCFD).Data());
+
+
+        //canvas1->Print(TString::Format("./output/SignalCFD_%d_%d_%d_%d.pdf",hitn,sector,layer,component));
+	canvas1->Print(filename);
+        delete gr1; delete gr2; delete canvas1;
+        delete axis1; delete legend;
+}

--- a/hitprocess/clas12/alert/ahdc_hitprocess.h
+++ b/hitprocess/clas12/alert/ahdc_hitprocess.h
@@ -87,38 +87,62 @@ public:
 #include <string>
 #include "CLHEP/GenericFunctions/Landau.hh"
 
+/**
+ * @class ahdcSignal
+ * 
+ * @brief ahdc signal simulation
+ *
+ * This class simulates the waveform of the ahdc signal and provide 
+ * algorithms to extract relevant informations from this signal.
+ *
+ * @author Felix Touchte Codjo
+ */
 class ahdcSignal {
-	// MHit identifiers
-	private : 
-		int hitn;
-		int sector;
-		int layer;
-		int component;
-		int nsteps;
+	// MHit or wires identifiers
+	public : 
+		int hitn; ///< n-th MHit of the event, also corresponds to the n-th activated wire
+		int sector; ///< sector, first wire identifier
+		int layer; ///< layer, second wire identifer
+		int component; ///< component, third wire identifier
+		int nsteps; ///< number of steps in this MHit, i.e number of Geant4 calculation steps in the sensitive area of the wire 
 	// vectors
 	private :
-		std::vector<double> Edep; // keV
-		std::vector<double> G4Time; // ns
-		std::vector<double> Doca; //mm
-		std::vector<double> DriftTime; // ns
+		std::vector<double> Edep; ///< array of deposited energy in each step [keV]
+		std::vector<double> G4Time; ///< array of Geant4 time corresponding to each step [ns]
+		std::vector<double> Doca; ///< array of distance of closest approach corresponding each step [mm]
+		std::vector<double> DriftTime; ///< array of drift time corresponding each step [ns]
+		
+		/**
+		 * @brief Fill the arrays Doca and DriftTime
+		 * 
+		 * Compute the doca corresponding to each step and
+		 * deducte the driftime using a "time to distance"
+		 * relation
+		 *
+		 * @param aHit an object derived from Geant4 "G4VHit" class
+		 */
 		void ComputeDocaAndTime(MHit * aHit);
-		std::vector<double> Dgtz; 
-		std::vector<double> Noise;
+		std::vector<double> Dgtz; ///< Array containing the samples of the simulated signal
+		std::vector<double> Noise; ///< Array containing the samples of the simulated noise
 	// setting parameters for digitization
 	private : 
-		double tmin = 0; 
-		double tmax = 6000; 
-		double delay = 1000;
-		double samplingTime = 44;      // ns
-		double electronYield = 9500;   // ADC_gain
-		int    adc_max = 4095; // 12 digits : 2^12-1
-		double Landau_width = 240; // 600/2.5;
+		const double tmin; ///< lower limit of the simulated time window
+		const double tmax; ///< upper limit of the simulated time window
+		const double timeOffset; ///< time offset for simulation purpose
+		const double samplingTime; ///< sampling time [ns]
+		const double Landau_width; ///< Width pararemeter of the Landau distribution
+		double electronYield = 9500;   ///< ADC gain
+		static const int ADC_LIMIT = 4095; ///< ADC limit, corresponds to 12 digits : 2^12-1
 	// public methods
 	public :
+		/** @brief Default constructor */
 		ahdcSignal() = default;
-		ahdcSignal(MHit * aHit, int hitn_){
+		
+		/** @brief Constructor */
+		ahdcSignal(MHit * aHit, int _hitn, double _tmin, double _tmax, double _timeOffset, double _samplingTime, double _Landau_width) 
+		: tmin(_tmin), tmax(_tmax), timeOffset(_timeOffset), samplingTime(_samplingTime), Landau_width(_Landau_width) {
 			// read identifiers
-			hitn = hitn_;
+			hitn = _hitn;
 			vector<identifier> identity = aHit->GetId();
 			sector = 0;
 			layer = 10 * identity[0].id + identity[1].id ; // 10*superlayer + layer
@@ -130,62 +154,122 @@ class ahdcSignal {
 			G4Time = aHit->GetTime();
 			this->ComputeDocaAndTime(aHit); // fills Doca and DriftTime
 		}
-
+		
+		/** @brief Destructor */
 		~ahdcSignal(){;}
-		int  					Get_hitn() {return hitn;}
-		int  					Get_sector() {return sector;}
-		int 					Get_layer() {return layer;}
-		int 					Get_component() {return component;}
-		int 					Get_nsteps() {return nsteps;}
-
-		double 					GetSamplingTime()	{return samplingTime;}
-		double                                  GetElectronYield()	{return electronYield;}
-		int	                                GetAdcMax()		{return adc_max;}
-		double 					GetTmin()               {return tmin;}
-		double                                  GetTmax()               {return tmax;}
-		double 					GetDelay()              {return delay;}
-		double 					GetLandauWidth() 	{return Landau_width;}
-
+		
+		/** @brief Return the value of the attribut `electronYield` */
+		double GetElectronYield() {return electronYield;}
+		
+		/** @brief Return the content of the attribut `Edep` */
 		std::vector<double>                     GetEdep() 		{return Edep;}
+		
+		/** @brief Return the content of the attribut `G4Time` */
 		std::vector<double>                     GetG4Time()		{return G4Time;}
+		
+		/** @brief Return the content of the attribut `Doca` */
 		std::vector<double>                     GetDoca()		{return Doca;}
+		
+		/** @brief Return the content of the attribut `DriftTime` */
 		std::vector<double>                     GetDriftTime()		{return DriftTime;}
+		
+		/** @brief Return the content of the attribut `Noise` */
 		std::vector<double>                     GetNoise()              {return Noise;}
+		
+		/** @brief Return the content of the attribut `Dgtz` */
 		std::vector<double> 			GetDgtz()		{return Dgtz;}
 		
-		// can be set, but only relevant before using the method "Digitize()"
-		void SetSamplingTime(double samplingTime_)		{samplingTime = samplingTime_;}
+		/**
+		 * @brief Set the electron yield. 
+		 * 
+		 * Only relevant before the use of the method `Digitize`
+		 */
 		void SetElectronYield(double electronYield_)		{electronYield = electronYield_;}
-		void SetAdcMax(int adc_)				{adc_max = adc_;}
-		void SetTmin(double tmin_)				{tmin = tmin_;}
-		void SetTmax(double tmax_)                              {tmax = tmax_;}
-		void SetDelay(double delay_) 				{delay = delay_;}
-		void SetLandauWith(double Landau_width_)		{Landau_width = Landau_width_;} 
-		void SetNoise(std::vector<double> Noise_)               {Noise = Noise_;}
-
-		double operator()(double t){
+		
+		/**
+		 * @brief Overloaded `()` operator to get the value of the signal at a given time.
+		 * 
+		 * @param t Time at which to calculate the signal's value
+		 *
+		 * @return Value of the signal at the time `t`
+		 */
+		double operator()(double timePoint){
 			using namespace Genfun;
-			double res = 0;
+			double signalValue = 0;
 			for (int s=0; s<nsteps; s++){
 				// setting Landau's parameters
 				Landau L;
 				L.peak() = Parameter("Peak",DriftTime.at(s),tmin,tmax); 
 				L.width() = Parameter("Width",Landau_width,0,400); 
-				res += Edep.at(s)*L(t-delay);
+				signalValue += Edep.at(s)*L(timePoint-timeOffset);
 			}
-			return res;
+			return signalValue;
 		}
-
+		
+		/**
+		 * @brief Digitize the simulated signal
+		 *
+		 * This method perfoms several steps
+		 * - step 1 : it produces samples from the simulated signal (using `samplingTime`)
+		 * - step 2 : it converts keV/ns in ADC units (using `electronYield`)
+		 * - step 3 : it adds noise
+		 *
+		 * @return Fill the attributs `Dgtz` and `Noise` 
+		 */
 		void Digitize();
+
+		/** @brief Generate gaussian noise
+		 *
+		 * @return Fill the attribut `Noise`
+		 */
 		void GenerateNoise(double mean, double stdev);
 		
-		// Decoding
+		// Decoding ouput
 		std::map<std::string,double> Decode();
 		double Apply_CFD(double CFD_fraction, int CFD_delay); // CFD_delay in index unit
 		double GetMCTime();
 		double GetMCEtot();		
-	};
+};
 
+
+/**
+ * @class ahdcExtractor
+ * 
+ * @author Felix Touchte Codjo
+ */
+class ahdcExtractor {
+	private :
+		float samplingTime;
+		int sparseSample;
+		short adcOffset;
+		long timeStamp;
+		float fineTimeStampResolution;
+		static const short ADC_LIMIT = 4095; // 2^12-1
+		float amplitudeFractionCFA;
+		int binDelayCFD;
+		float fractionCFD;
+	
+	public :
+		int binMax; ///< Bin of the max ADC over the pulse
+                int binOffset; ///< Offset due to sparse sample
+                float adcMax; ///< Max value of ADC over the pulse (fitted)
+                float timeMax; ///< Time of the max ADC over the pulse (fitted)
+                float integral; ///< Sum of ADCs over the pulse (not fitted)
+
+		std::vector<short> samplesCorr; ///< Waveform after offset (pedestal) correction
+                int binNumber; ///< Number of bins in one waveform
+
+                float timeRiseCFA; ///< moment when the signal reaches a Constant Fraction of its Amplitude uphill (fitted)
+                float timeFallCFA; ///< moment when the signal reaches a Constant Fraction of its Amplitude downhill (fitted)
+                float timeOverThresholdCFA; ///< is equal to (timeFallCFA - timeRiseCFA)
+                float timeCFD; ///< time extracted using the Constant Fraction Discriminator (CFD) algorithm (fitted)
+
+		ahdcExtractor() = default;
+
+		~ahdcExtractor(){;}
+		
+		void extract(std::vector<short> samples);
+};
 
 #endif
 

--- a/hitprocess/clas12/alert/ahdc_hitprocess.h
+++ b/hitprocess/clas12/alert/ahdc_hitprocess.h
@@ -342,8 +342,6 @@ class ahdcExtractor {
 		void computeTimeUsingConstantFractionDiscriminator();
 	public:	
 		std::vector<float> samplesCFD; ///< samples corresponding to the CFD signal
-		void Show(const char * filename);
-		void ShowCFD(const char * filename);
 };
 
 #endif

--- a/output/hipoSchemas.cc
+++ b/output/hipoSchemas.cc
@@ -98,7 +98,7 @@ HipoSchema :: HipoSchema()
 
 	
 	// detectors
-	alertAhdcADCchema.parse("sector/B, layer/B, component/S, order/B, ADC/I, time/F, ped/S, integral/I, timestamp/L, t_start/F, t_cfd/F, mctime/F, nsteps/I, mcEtot/F");
+	alertAhdcADCchema.parse("sector/B, layer/B, component/S, order/B, ADC/I, time/F, ped/S, integral/I, timestamp/L, timeRiseCFA/F, timeCFD/F, timeOVR/F, mctime/F, mcEtot/F, nsteps/I");
 	std::ostringstream ListOfAhdcWF136;
 	ListOfAhdcWF136 << "sector/B, layer/B, component/S, order/B, timestamp/L";
 	for (int itr=1;itr<=136;itr++){


### PR DESCRIPTION
In this pull request, I have enhanced the readability of the AHDC digitisation. 

Features :

- More comments
- Simulation and extraction are done using two different classes (`ahdcSignal` and `ahdcExtractor`)
- Self understandable output name (example : `timeRiseCFA` for _moment when the signal reaches a Constant Fraction of its Amplitude uphill_)

![Capture d’écran de 2024-11-18 12-15-41](https://github.com/user-attachments/assets/c2f7b08e-4af6-4758-b7d4-5c65017d61e7)
![Capture d’écran de 2024-11-18 12-16-35](https://github.com/user-attachments/assets/50079c63-0cd4-4d0c-be3c-7fe6b159ab7a)

![Capture d’écran de 2024-11-18 12-09-23](https://github.com/user-attachments/assets/a7c56469-a162-4386-8206-8c652c516b13)

![Capture d’écran de 2024-11-18 12-19-24](https://github.com/user-attachments/assets/01d31002-9e98-4a07-8cf4-c4781011bb33)


